### PR TITLE
fixed small cmake error

### DIFF
--- a/Editor/CMakeLists.txt
+++ b/Editor/CMakeLists.txt
@@ -13,9 +13,6 @@ set_target_properties(Editor PROPERTIES
 # Link the editor with the game engine
 target_link_libraries(Editor PRIVATE Idra)
 
-# Ensure the game engine headers are available
-target_include_directories(Editor PRIVATE ${CMAKE_SOURCE_DIR}/Idra)
-
 add_custom_command(TARGET Editor POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
         $<TARGET_FILE:Idra> $<TARGET_FILE_DIR:Editor>

--- a/Idra/CMakeLists.txt
+++ b/Idra/CMakeLists.txt
@@ -12,4 +12,4 @@ set_target_properties(Idra PROPERTIES
 )
 
 # Export include directories
-target_include_directories(Idra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/Idra)
+target_include_directories(Idra PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
This pull request includes changes to the `CMakeLists.txt` files for the `Editor` and `Idra` projects to streamline the inclusion of directories and ensure proper linkage.

Changes to directory inclusion:

* [`Editor/CMakeLists.txt`](diffhunk://#diff-58201587860cc1986da9e5bc729e411b269faa2bf0bedcb94407978f47ecb6e9L16-L18): Removed the explicit inclusion of the `Idra` directory to simplify the configuration.
* [`Idra/CMakeLists.txt`](diffhunk://#diff-5508f8017328f3fde8dffbccc94e1c16fee4cdfcb96e5ae16115099c89b49e35L15-R15): Adjusted the directory inclusion to use the current source directory instead of a subdirectory, ensuring consistency and potentially reducing errors.