### PR TITLE
Small comments made and 1 warning fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,11 @@ add_subdirectory(Editor)
 
 set_target_properties(${CMAKE_TARGET_NAME} PROPERTIES LINKER_LANGUAGE CXX)
 
+# use the static runtime library for MSVC
 set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
+
+# use the dynamic runtime library for MSVC
+# set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL$<$<CONFIG:Debug>:Debug>")
 
 install(TARGETS ${CMAKE_TARGET_NAME}
 	RUNTIME DESTINATION bin

--- a/Idra/CMakeLists.txt
+++ b/Idra/CMakeLists.txt
@@ -21,7 +21,6 @@ set_target_properties(Idra PROPERTIES
 
 # set macro for exporting symbols for the engine
 target_compile_definitions(Idra PRIVATE 
-    IDRA_CORE_EXPORT 
     GLFW_INCLUDE_NONE
     IDRA_DEBUG_MODE
 )

--- a/Idra/include/Core/Core.h
+++ b/Idra/include/Core/Core.h
@@ -2,14 +2,14 @@
 
 #ifdef _WIN32
 	#define IDRA_WINDOW_GLFW
-#	ifdef IDRA_BUILD_DLL
+	#ifdef IDRA_BUILD_DLL
 		#ifdef IDRA_CORE_EXPORT
 			#define IDRA_API __declspec(dllexport)
 		#else
 			#define IDRA_API __declspec(dllimport)
 		#endif
 	#else
-		#define IDRA_API
+		#define IDRA_API // else ignore Macro, as we are building a static library
 	#endif
 #else
 	#error Only Windows is supported!

--- a/Idra/src/ImGui/ImGuiLayer.cpp
+++ b/Idra/src/ImGui/ImGuiLayer.cpp
@@ -90,7 +90,7 @@ namespace Idra
 	{
 		ImGuiIO& io = ImGui::GetIO();
 		Application& app = Application::Get();
-		io.DisplaySize = ImVec2(app.GetWindow().GetWidth(), app.GetWindow().GetHeight());
+		io.DisplaySize = ImVec2((float)app.GetWindow().GetWidth(), (float)app.GetWindow().GetHeight());
 
 		ImGui::Render();
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());


### PR DESCRIPTION
This pull request includes changes to improve compatibility with static libraries, refine macro usage, and address type safety issues. The most important changes are grouped into themes below.

### Compatibility with static libraries:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR16-R21): Updated to use the static runtime library for MSVC by default (`MultiThreaded`) and commented out the dynamic runtime library configuration (`MultiThreadedDLL`).
* [`Idra/include/Core/Core.h`](diffhunk://#diff-4e633778c3e6275f70bcbf35c1d53abf161aacb0c0228ae3cea7b84c6da4ad5fL12-R12): Updated the `IDRA_API` macro to include a comment clarifying that it is ignored when building a static library.

### Macro and symbol definition refinements:

* [`Idra/CMakeLists.txt`](diffhunk://#diff-5508f8017328f3fde8dffbccc94e1c16fee4cdfcb96e5ae16115099c89b49e35L24): Removed the `IDRA_CORE_EXPORT` macro from the `target_compile_definitions` for the `Idra` target, as it is no longer needed.

### Type safety improvements:

* [`Idra/src/ImGui/ImGuiLayer.cpp`](diffhunk://#diff-9cc954ed72fdc171c1d3ba90dfd22b61283d68c0990e84ac6c27b2d8fb94367eL93-R93): Explicitly cast window dimensions to `float` when setting `io.DisplaySize` in the ImGui layer to ensure type safety.