### PR TITLE
First Render

### DIFF
--- a/Idra/include/Core/Application.h
+++ b/Idra/include/Core/Application.h
@@ -32,6 +32,11 @@ namespace Idra {
 		ImGuiLayer* m_ImGuiLayer;
 		bool m_Running = true;
 		LayerStack m_LayerStack;
+
+		// TEMP
+		unsigned int m_VertexArray;
+		unsigned int m_VertexBuffer;
+		unsigned int m_IndexBuffer;
 	private:
 		static Application* s_Instance;
 	};

--- a/Idra/src/Core/Application.cpp
+++ b/Idra/src/Core/Application.cpp
@@ -19,6 +19,38 @@ namespace Idra {
 
 		m_ImGuiLayer = new ImGuiLayer();
 		PushOverlay(m_ImGuiLayer);
+
+		glGenVertexArrays(1, &m_VertexArray);
+		glBindVertexArray(m_VertexArray);
+
+		glGenBuffers(1, &m_VertexBuffer);
+		glBindBuffer(GL_ARRAY_BUFFER, m_VertexBuffer);
+
+		// Vertex data: position (x, y, z), texture coordinates (u, v)
+		float vertices[3 * 7] = {
+			-0.5f, -0.5f, 0.0f, 0.0f, 0.0f,
+			 0.5f, -0.5f, 0.0f, 1.0f, 0.0f,
+			 0.5f,  0.5f, 0.0f, 1.0f, 1.0f,
+			-0.5f,  0.5f, 0.0f, 0.0f, 1.0f
+		};
+
+		glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+
+		glEnableVertexAttribArray(0);
+		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
+		glEnableVertexAttribArray(1);
+		glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
+
+		glGenBuffers(1, &m_IndexBuffer);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_IndexBuffer);
+		unsigned int indices[6] = {
+			0, 1, 2,
+			2, 3, 0
+		};
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
+
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+		glBindVertexArray(0);
 	}
 
 	Application::~Application()
@@ -34,6 +66,9 @@ namespace Idra {
 		{
 			glClearColor(0.2f, 0.3f, 0.3f, 1.0f);
 			glClear(GL_COLOR_BUFFER_BIT);
+
+			glBindVertexArray(m_VertexArray);
+			glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
 
 			for (Layer* layer : m_LayerStack)
 				layer->OnUpdate();


### PR DESCRIPTION
This pull request introduces temporary OpenGL rendering functionality to the `Application` class in the `Idra` project. It adds support for rendering a simple textured quad using vertex and index buffers. These changes are intended for testing or prototyping purposes and are marked as temporary.

### OpenGL Rendering Setup:

* Added temporary member variables `m_VertexArray`, `m_VertexBuffer`, and `m_IndexBuffer` to the `Application` class for managing OpenGL buffers. (`Idra/include/Core/Application.h`, [Idra/include/Core/Application.hR35-R39](diffhunk://#diff-43dca16ed73b68a6005e9770b67528b8e247eb19982ebb4cbf11d8e5b8498af7R35-R39))
* Initialized OpenGL buffers in the `Application` constructor:
  - Created and bound vertex arrays and buffers.
  - Defined vertex data for a textured quad and uploaded it to the GPU.
  - Configured vertex attributes for position and texture coordinates.
  - Created and bound an index buffer with indices for rendering a quad. (`Idra/src/Core/Application.cpp`, [Idra/src/Core/Application.cppR22-R53](diffhunk://#diff-85e9aae16b6328528c04a282beb6028495dbc9224b97fde23e8deaa7792ec0c3R22-R53))

### OpenGL Rendering Execution:

* Added rendering logic to the `Application::Run` method:
  - Bound the vertex array and issued a `glDrawElements` call to render the quad using the index buffer. (`Idra/src/Core/Application.cpp`, [Idra/src/Core/Application.cppR70-R72](diffhunk://#diff-85e9aae16b6328528c04a282beb6028495dbc9224b97fde23e8deaa7792ec0c3R70-R72))