### PR TITLE
Renderer API Abstraction

### DIFF
--- a/Idra/CMakeLists.txt
+++ b/Idra/CMakeLists.txt
@@ -12,7 +12,9 @@ add_library(Idra STATIC
     "src/Platform/Windows/WindowsInput.cpp"
     "src/Platform/Windows/WindowsWindow.cpp"
     "src/Renderer/Shader.cpp"
-)
+    "src/Renderer/Buffer.cpp" 
+    "src/Renderer/Renderer.cpp"
+    "src/Platform/OpenGL/OpenGLBuffer.cpp")
 
 # Set the output directories for the library
 set_target_properties(Idra PROPERTIES

--- a/Idra/include/Core/Application.h
+++ b/Idra/include/Core/Application.h
@@ -10,6 +10,8 @@
 
 //TEMP
 #include "Renderer/Shader.h"
+#include "Renderer/Renderer.h"
+#include "Renderer/Buffer.h"
 
 namespace Idra {
 
@@ -38,10 +40,10 @@ namespace Idra {
 
 		// TEMP
 		unsigned int m_VertexArray;
-		unsigned int m_VertexBuffer;
-		unsigned int m_IndexBuffer;
 
 		std::unique_ptr<Shader> m_Shader;
+		std::unique_ptr<VertexBuffer> m_VertexBuffer;
+		std::unique_ptr<IndexBuffer> m_IndexBuffer;
 	private:
 		static Application* s_Instance;
 	};

--- a/Idra/include/Platform/OpenGL/OpenGLBuffer.h
+++ b/Idra/include/Platform/OpenGL/OpenGLBuffer.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "Core/Core.h"
+
+#include "Renderer/Buffer.h"
+
+namespace Idra {
+	class IDRA_API OpenGLVertexBuffer : public VertexBuffer
+	{
+	public:
+		OpenGLVertexBuffer(float* vertices, uint32_t size);
+		virtual ~OpenGLVertexBuffer();
+
+		virtual void Bind() const override;
+		virtual void Unbind() const override;
+	private:
+		uint32_t m_RendererID;
+	};
+
+	class IDRA_API OpenGLIndexBuffer : public IndexBuffer
+	{
+	public:
+		OpenGLIndexBuffer(uint32_t* indices, uint32_t count);
+		virtual ~OpenGLIndexBuffer();
+
+		virtual void Bind() const override;
+		virtual void Unbind() const override;
+
+		virtual uint32_t GetCount() const override { return m_Count; }
+	private:
+		uint32_t m_Count;
+		uint32_t m_RendererID;
+	};
+}

--- a/Idra/include/Renderer/Buffer.h
+++ b/Idra/include/Renderer/Buffer.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "Core/Core.h"
+
+namespace Idra {
+
+	class IDRA_API VertexBuffer
+	{
+	public:
+		virtual ~VertexBuffer() = default;
+
+		virtual void Bind() const = 0;
+		virtual void Unbind() const = 0;
+
+		static VertexBuffer* Create(float* vertices, uint32_t size);
+	};
+
+	class IDRA_API IndexBuffer
+	{
+	public:
+		virtual ~IndexBuffer() = default;
+
+		virtual void Bind() const = 0;
+		virtual void Unbind() const = 0;
+
+		virtual uint32_t GetCount() const = 0;
+
+		static IndexBuffer* Create(uint32_t* indices, uint32_t count);
+	};
+}

--- a/Idra/include/Renderer/Renderer.h
+++ b/Idra/include/Renderer/Renderer.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "Core/Core.h"
+
+namespace Idra {
+	enum class IDRA_API RendererAPI
+	{
+		None = 0,
+		OpenGL = 1,
+		DirectX = 2,
+		Vulkan = 3
+	};
+
+	class IDRA_API Renderer
+	{
+	public:
+		inline static RendererAPI GetAPI() { return s_RendererAPI; }
+	private:
+		static RendererAPI s_RendererAPI;
+	};
+}

--- a/Idra/src/Core/Application.cpp
+++ b/Idra/src/Core/Application.cpp
@@ -23,9 +23,6 @@ namespace Idra {
 		glGenVertexArrays(1, &m_VertexArray);
 		glBindVertexArray(m_VertexArray);
 
-		glGenBuffers(1, &m_VertexBuffer);
-		glBindBuffer(GL_ARRAY_BUFFER, m_VertexBuffer);
-
 		// Vertex data: position (x, y, z), texture coordinates (u, v)
 		float vertices[3 * 7] = {
 			-0.5f, -0.5f, 0.0f, 0.0f, 0.0f,
@@ -34,23 +31,19 @@ namespace Idra {
 			-0.5f,  0.5f, 0.0f, 0.0f, 1.0f
 		};
 
-		glBufferData(GL_ARRAY_BUFFER, sizeof(vertices), vertices, GL_STATIC_DRAW);
+		m_VertexBuffer.reset(VertexBuffer::Create(vertices, sizeof(vertices)));
 
 		glEnableVertexAttribArray(0);
 		glVertexAttribPointer(0, 3, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)0);
 		glEnableVertexAttribArray(1);
 		glVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, 5 * sizeof(float), (void*)(3 * sizeof(float)));
 
-		glGenBuffers(1, &m_IndexBuffer);
-		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_IndexBuffer);
-		unsigned int indices[6] = {
+		uint32_t indices[6] = {
 			0, 1, 2,
 			2, 3, 0
 		};
-		glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indices), indices, GL_STATIC_DRAW);
 
-		glBindBuffer(GL_ARRAY_BUFFER, 0);
-		glBindVertexArray(0);
+		m_IndexBuffer.reset(IndexBuffer::Create(indices, sizeof(indices) / sizeof(uint32_t)));
 
 		// TEMP
 		// Load and compile the vertex shader
@@ -109,7 +102,7 @@ namespace Idra {
 
 			m_Shader->Bind();
 			glBindVertexArray(m_VertexArray);
-			glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, 0);
+			glDrawElements(GL_TRIANGLES, m_IndexBuffer->GetCount(), GL_UNSIGNED_INT, 0);
 
 			for (Layer* layer : m_LayerStack)
 				layer->OnUpdate();

--- a/Idra/src/Platform/OpenGL/OpenGLBuffer.cpp
+++ b/Idra/src/Platform/OpenGL/OpenGLBuffer.cpp
@@ -1,0 +1,55 @@
+#include "IdraPCH.h"
+
+#include "Platform/OpenGL/OpenGLBuffer.h"
+
+#include <glad/glad.h>
+
+namespace Idra {
+
+	///////////////////////////////////////////////////////////////////////
+	// VertexBuffer ///////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+
+	OpenGLVertexBuffer::OpenGLVertexBuffer(float* vertices, uint32_t size)
+	{
+		glCreateBuffers(1, &m_RendererID);
+		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ARRAY_BUFFER, size, vertices, GL_STATIC_DRAW);
+	}
+	OpenGLVertexBuffer::~OpenGLVertexBuffer()
+	{
+		glDeleteBuffers(1, &m_RendererID);
+	}
+	void OpenGLVertexBuffer::Bind() const
+	{
+		glBindBuffer(GL_ARRAY_BUFFER, m_RendererID);
+	}
+	void OpenGLVertexBuffer::Unbind() const
+	{
+		glBindBuffer(GL_ARRAY_BUFFER, 0);
+	}
+
+	///////////////////////////////////////////////////////////////////////
+	// IndexBuffer ////////////////////////////////////////////////////////
+	///////////////////////////////////////////////////////////////////////
+
+	OpenGLIndexBuffer::OpenGLIndexBuffer(uint32_t* indices, uint32_t count)
+		: m_Count(count)
+	{
+		glCreateBuffers(1, &m_RendererID);
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
+		glBufferData(GL_ELEMENT_ARRAY_BUFFER, count * sizeof(uint32_t), indices, GL_STATIC_DRAW);
+	}
+	OpenGLIndexBuffer::~OpenGLIndexBuffer()
+	{
+		glDeleteBuffers(1, &m_RendererID);
+	}
+	void OpenGLIndexBuffer::Bind() const
+	{
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, m_RendererID);
+	}
+	void OpenGLIndexBuffer::Unbind() const
+	{
+		glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+	}
+}

--- a/Idra/src/Renderer/Buffer.cpp
+++ b/Idra/src/Renderer/Buffer.cpp
@@ -1,0 +1,39 @@
+#include "IdraPCH.h"
+
+#include "Renderer/Renderer.h"
+#include "Renderer/Buffer.h"
+
+#include "Platform/OpenGL/OpenGLBuffer.h"
+
+namespace Idra {
+
+	VertexBuffer* VertexBuffer::Create(float* vertices, uint32_t size)
+	{
+		switch (Renderer::GetAPI())
+		{
+			case RendererAPI::None: 
+				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!");
+				return nullptr;
+			case RendererAPI::OpenGL: 
+				return new OpenGLVertexBuffer(vertices, size);
+		}
+
+		IDRA_CORE_ASSERT(false, "Unknown RendererAPI!");
+		return nullptr;
+	}
+
+	IndexBuffer* IndexBuffer::Create(uint32_t* indices, uint32_t count)
+	{
+		switch (Renderer::GetAPI())
+		{
+			case RendererAPI::None: 
+				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!"); 
+				return nullptr;
+			case RendererAPI::OpenGL: 
+				return new OpenGLIndexBuffer(indices, count);
+		}
+
+		IDRA_CORE_ASSERT(false, "Unknown RendererAPI!");
+		return nullptr;
+	}
+}

--- a/Idra/src/Renderer/Renderer.cpp
+++ b/Idra/src/Renderer/Renderer.cpp
@@ -1,0 +1,7 @@
+#include "Renderer/Renderer.h"
+
+namespace Idra {
+
+	RendererAPI Renderer::s_RendererAPI = RendererAPI::OpenGL;
+
+}

--- a/Idra/src/Renderer/Shader.cpp
+++ b/Idra/src/Renderer/Shader.cpp
@@ -63,6 +63,9 @@ namespace Idra {
 
 		unsigned int glType;
 
+		// @TODO: check to see if vertex and fragment shaders are already attached
+		// maybe override it or just ignore it
+
 		switch (type)
 		{
 		case ShaderType::VERTEX_SHADER:


### PR DESCRIPTION
This pull request introduces a major refactor and enhancement of the rendering system in the `Idra` engine by implementing an abstraction layer for vertex and index buffers, adding support for multiple rendering APIs, and integrating OpenGL-specific implementations. The changes improve modularity, maintainability, and scalability of the rendering pipeline. Below are the most important changes grouped by theme:

### Renderer Abstraction and API Integration:

* Introduced abstract `VertexBuffer` and `IndexBuffer` classes in `Idra/include/Renderer/Buffer.h`, providing a unified interface for buffer operations. These classes include methods for creation, binding, unbinding, and retrieving buffer properties.
* Added the `Renderer` class and `RendererAPI` enum in `Idra/include/Renderer/Renderer.h` to manage the rendering API selection and encapsulate API-specific logic.

### OpenGL-Specific Implementations:

* Implemented `OpenGLVertexBuffer` and `OpenGLIndexBuffer` classes in `Idra/include/Platform/OpenGL/OpenGLBuffer.h` and their methods in `Idra/src/Platform/OpenGL/OpenGLBuffer.cpp`. These classes provide OpenGL-specific implementations of the abstract buffer interfaces. [[1]](diffhunk://#diff-21e0e53d148722da2c87ba37bbe87cca4eb26a99199696dddb3c5660b33a2706R1-R34) [[2]](diffhunk://#diff-714c99f2e22bb34d7e7df14458ffc8ad517f600efeb515b03c2f2792e49b071dR1-R55)
* Added logic in `Idra/src/Renderer/Buffer.cpp` to create appropriate buffer instances based on the selected `RendererAPI`. Currently, OpenGL is the only supported API.

### Core Application Refactor:

* Updated `Idra/include/Core/Application.h` and `Idra/src/Core/Application.cpp` to replace raw OpenGL buffer management with the new `VertexBuffer` and `IndexBuffer` abstractions. This includes using `std::unique_ptr` for buffer ownership and replacing OpenGL-specific calls with abstraction methods. [[1]](diffhunk://#diff-43dca16ed73b68a6005e9770b67528b8e247eb19982ebb4cbf11d8e5b8498af7L41-R46) [[2]](diffhunk://#diff-85e9aae16b6328528c04a282beb6028495dbc9224b97fde23e8deaa7792ec0c3L37-R46) [[3]](diffhunk://#diff-85e9aae16b6328528c04a282beb6028495dbc9224b97fde23e8deaa7792ec0c3L112-R105)

### CMake Configuration:

* Updated `Idra/CMakeLists.txt` to include new source files (`Buffer.cpp`, `Renderer.cpp`, `OpenGLBuffer.cpp`) in the `Idra` library build configuration.

### Miscellaneous:

* Added a default implementation for the `RendererAPI` in `Idra/src/Renderer/Renderer.cpp`, setting it to `OpenGL` by default.
* Added a `TODO` comment in `Idra/src/Renderer/Shader.cpp` to handle cases where vertex and fragment shaders might already be attached.