### PR TITLE
Created Ref and Scope Pointers

### DIFF
--- a/Editor/include/SandboxLayer.h
+++ b/Editor/include/SandboxLayer.h
@@ -39,14 +39,14 @@ private:
 	glm::vec3 m_Colour = { 0.2f, 0.3f, 0.8f };
 
 	// TEMP
-	std::shared_ptr<Idra::Shader> m_Shader;
-	std::shared_ptr<Idra::Shader> m_TextureShader;
-	std::shared_ptr<Idra::Shader> m_FlatColourShader;
-	std::shared_ptr<Idra::Model> m_Model_Sphere;
-	std::shared_ptr<Idra::Model> m_Model_Cube;
-	std::shared_ptr<Idra::Model> m_Model_D20;
-	std::shared_ptr<Idra::Texture2D> m_Texture;
-	std::shared_ptr<Idra::Texture2D> m_AlphaTexture;
+	Idra::Ref<Idra::Shader> m_Shader;
+	Idra::Ref<Idra::Shader> m_TextureShader;
+	Idra::Ref<Idra::Shader> m_FlatColourShader;
+	Idra::Ref<Idra::Model> m_Model_Sphere;
+	Idra::Ref<Idra::Model> m_Model_Cube;
+	Idra::Ref<Idra::Model> m_Model_D20;
+	Idra::Ref<Idra::Texture2D> m_Texture;
+	Idra::Ref<Idra::Texture2D> m_AlphaTexture;
 
 	// TEMP transforms
 	Idra::TransformComponent m_Transform_Sphere;
@@ -55,8 +55,8 @@ private:
 
 	Idra::ModelLoaderType m_ModelLoaderType = Idra::ModelLoaderType::Assimp;
 
-	std::shared_ptr<Idra::Camera> m_Camera;
-	std::shared_ptr<Idra::CameraController> m_EditorCameraController;
+	Idra::Ref<Idra::Camera> m_Camera;
+	Idra::Ref<Idra::CameraController> m_EditorCameraController;
 };
 
 

--- a/Editor/src/SandboxLayer.cpp
+++ b/Editor/src/SandboxLayer.cpp
@@ -17,38 +17,38 @@ SandboxLayer::SandboxLayer()
 	Idra::PerspectiveCameraSpec perspCameraSpec;
 	Idra::OrthographicCameraSpec orthoCameraSpec;
 
-	m_Camera.reset(Idra::Camera::CreateCamera(Idra::CameraProjectionType::Perspective, &perspCameraSpec));
-	//m_Camera.reset(Idra::Camera::CreateCamera(Idra::CameraProjectionType::Orthographic, &orthoCameraSpec));
-	m_EditorCameraController.reset(Idra::CameraController::CreateCameraController(Idra::CameraControllerType::EditorCamera));
+	m_Camera = Idra::Camera::CreateCamera(Idra::CameraProjectionType::Perspective, &perspCameraSpec);
+	//m_Camera = Idra::Camera::CreateCamera(Idra::CameraProjectionType::Orthographic, &orthoCameraSpec);
+	m_EditorCameraController = Idra::CameraController::CreateCameraController(Idra::CameraControllerType::EditorCamera);
 
 	// Set the camera position and rotation
 	m_Camera->SetPosition({ 3.0f, 2.0f, 10.0f });
 	m_Camera->SetRotation({ 0.0f, -1.0f, 0.0f });
 
 	// Load the model
-	m_Model_Sphere.reset(Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/ico-sphere.obj"));
-	m_Model_Cube.reset(Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/cube.obj"));
-	m_Model_D20.reset(Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/D20.obj"));
+	m_Model_Sphere = Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/ico-sphere.obj");
+	m_Model_Cube = Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/cube.obj");
+	m_Model_D20 = Idra::ModelLoader::LoadModel(m_ModelLoaderType, "Assets/Models/D20.obj");
 
 	// Load the texture
-	m_Texture.reset(Idra::Texture2D::Create("Assets/Textures/default.png"));
-	m_AlphaTexture.reset(Idra::Texture2D::Create("Assets/Textures/Alpha.png"));
+	m_Texture = Idra::Texture2D::Create("Assets/Textures/default.png");
+	m_AlphaTexture = Idra::Texture2D::Create("Assets/Textures/Alpha.png");
 
 	// Shaders
 	Path vertexSrc = "Assets/Shaders/Basic.vert";
 	Path fragmentSrc = "Assets/Shaders/Basic.frag";
-	m_Shader.reset(Idra::Shader::Create(vertexSrc, fragmentSrc));
+	m_Shader = Idra::Shader::Create(vertexSrc, fragmentSrc);
 
 	Path textureVertexSrc = "Assets/Shaders/BasicTexture.vert";
 	Path textureFragmentSrc = "Assets/Shaders/BasicTexture.frag";
-	m_TextureShader.reset(Idra::Shader::Create(textureVertexSrc, textureFragmentSrc));
+	m_TextureShader = Idra::Shader::Create(textureVertexSrc, textureFragmentSrc);
 
 	std::dynamic_pointer_cast<Idra::OpenGLShader>(m_TextureShader)->Bind();
 	std::dynamic_pointer_cast<Idra::OpenGLShader>(m_TextureShader)->SetUniform1i("u_Texture", 0);
 
 	Path flatColourVertexSrc = "Assets/Shaders/FlatColour.vert";
 	Path flatColourFragmentSrc = "Assets/Shaders/FlatColour.frag";
-	m_FlatColourShader.reset(Idra::Shader::Create(flatColourVertexSrc, flatColourFragmentSrc));
+	m_FlatColourShader = Idra::Shader::Create(flatColourVertexSrc, flatColourFragmentSrc);
 
 	// Transforms
 	m_Transform_Sphere.Position = { 0.0f, 2.0f, 0.0f };

--- a/Idra/include/Core/Core.h
+++ b/Idra/include/Core/Core.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <memory>
+
 #ifdef _WIN32
 	#define IDRA_WINDOW_GLFW
 	#ifdef IDRA_BUILD_DLL
@@ -30,3 +32,21 @@
 #define BIT(x) (1 << x)
 
 #define IDRA_BIND_EVENT_FN(fn) std::bind(&fn, this, std::placeholders::_1) // #DEBUG
+
+namespace Idra {
+	template<typename T> 
+	using Ref = std::shared_ptr<T>;
+	template<typename T, typename ... Args>
+	constexpr Ref<T> CreateRef(Args&& ... args)
+	{
+		return std::make_shared<T>(std::forward<Args>(args)...);
+	}
+
+	template<typename T>
+	using Scope = std::unique_ptr<T>;
+	template<typename T, typename ... Args>
+	constexpr Scope<T> CreateScope(Args&& ... args)
+	{
+		return std::make_unique<T>(std::forward<Args>(args)...);
+	}
+}

--- a/Idra/include/Platform/OpenGL/OpenGLRendererAPI.h
+++ b/Idra/include/Platform/OpenGL/OpenGLRendererAPI.h
@@ -13,6 +13,6 @@ namespace Idra {
 		virtual void SetClearColor(const glm::vec4& color) override;
 		virtual void Clear() override;
 
-		virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) override;
+		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) override;
 	};
 }

--- a/Idra/include/Platform/OpenGL/OpenGLVertexArray.h
+++ b/Idra/include/Platform/OpenGL/OpenGLVertexArray.h
@@ -14,15 +14,15 @@ namespace Idra {
 		virtual void Bind() const override;
 		virtual void Unbind() const override;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) override;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) override;
+		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) override;
+		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) override;
 
-		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const override { return m_VertexBuffers; }
-		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const override { return m_IndexBuffer; }
+		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const override { return m_VertexBuffers; }
+		virtual const Ref<IndexBuffer>& GetIndexBuffer() const override { return m_IndexBuffer; }
 
 	private:
-		std::vector<std::shared_ptr<VertexBuffer>> m_VertexBuffers;
-		std::shared_ptr<IndexBuffer> m_IndexBuffer;
+		std::vector<Ref<VertexBuffer>> m_VertexBuffers;
+		Ref<IndexBuffer> m_IndexBuffer;
 		uint32_t m_RendererID;
 	};
 }

--- a/Idra/include/Renderer/Buffer.h
+++ b/Idra/include/Renderer/Buffer.h
@@ -89,8 +89,7 @@ namespace Idra {
 		virtual void SetLayout(const BufferLayout& layout) = 0;
 		virtual const BufferLayout& GetLayout() const = 0;
 
-		static VertexBuffer* Create(const std::vector<float>&);
-		static VertexBuffer* Create(float* vertices, uint32_t size);
+		static Ref<VertexBuffer> Create(const std::vector<float>&);
 	};
 
 	class IDRA_API IndexBuffer
@@ -103,7 +102,6 @@ namespace Idra {
 
 		virtual uint32_t GetCount() const = 0;
 
-		static IndexBuffer* Create(const std::vector<uint32_t>& indices);
-		static IndexBuffer* Create(uint32_t* indices, uint32_t count);
+		static Ref<IndexBuffer> Create(const std::vector<uint32_t>& indices);
 	};
 }

--- a/Idra/include/Renderer/Camera.h
+++ b/Idra/include/Renderer/Camera.h
@@ -42,7 +42,7 @@ namespace Idra {
 		* @param spec The camera specification (optional). Based on the type, it can be a PerspectiveCameraSpec or OrthographicCameraSpec.
 		* @return A pointer to the created camera, either PerspectiveCamera or OrthographicCamera.
 		*/
-		static Camera* CreateCamera(CameraProjectionType type, const void* spec = nullptr);
+		static Ref<Camera> CreateCamera(CameraProjectionType type, const void* spec = nullptr);
 
 		const float GetNearClip() const { return m_NearClip; }
 		void SetNearClip(float nearClip) { m_NearClip = nearClip; UpdateProjectionMatrix(); }

--- a/Idra/include/Renderer/CameraController.h
+++ b/Idra/include/Renderer/CameraController.h
@@ -19,7 +19,7 @@ namespace Idra {
 	public:
 		virtual ~CameraController() = default;
 
-		static CameraController* CreateCameraController(CameraControllerType type);
+		static Ref<CameraController> CreateCameraController(CameraControllerType type);
 
 		virtual void OnUpdate(Camera& camera, Timestep ts) = 0;
 		virtual void OnEvent(Camera& camera, Event& e) = 0;

--- a/Idra/include/Renderer/RenderCommand.h
+++ b/Idra/include/Renderer/RenderCommand.h
@@ -23,11 +23,11 @@ namespace Idra {
 			s_RendererAPI->Clear(); 
 		}
 
-		inline static void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) 
+		inline static void DrawIndexed(const Ref<VertexArray>& vertexArray) 
 		{ 
 			s_RendererAPI->DrawIndexed(vertexArray); 
 		}
 	private:
-		static RendererAPI* s_RendererAPI;
+		static Scope<RendererAPI> s_RendererAPI;
 	};
 }

--- a/Idra/include/Renderer/Renderer.h
+++ b/Idra/include/Renderer/Renderer.h
@@ -17,11 +17,11 @@ namespace Idra {
 	public:
 		static void Init();
 
-		static const void BeginScene(const std::shared_ptr<Camera>& camera);
+		static const void BeginScene(const Ref<Camera>& camera);
 		static void EndScene();
 
-		static void Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<Mesh>& mesh, const TransformComponent& transform);
-		static void Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<Model>& model, const TransformComponent& transform);
+		static void Submit(const Ref<Shader>& shader, const Ref<Mesh>& mesh, const TransformComponent& transform);
+		static void Submit(const Ref<Shader>& shader, const Ref<Model>& model, const TransformComponent& transform);
 
 		inline static RendererAPI::API GetAPI() { return RendererAPI::GetAPI(); }
 

--- a/Idra/include/Renderer/RendererAPI.h
+++ b/Idra/include/Renderer/RendererAPI.h
@@ -23,12 +23,12 @@ namespace Idra {
 		virtual void SetClearColor(const glm::vec4& color) = 0;
 		virtual void Clear() = 0;
 
-		virtual void DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray) = 0;
+		virtual void DrawIndexed(const Ref<VertexArray>& vertexArray) = 0;
 
 		inline static API GetAPI() { return s_API; }
 		static void SetAPI(API api) { s_API = api; }
 
-		static RendererAPI* Create();
+		static Scope<RendererAPI> Create();
 	private:
 		// @TODO: Set this to the renderer API of your choice
 		// in future we might want 1 viewport rendered in OpenGL and another in Vulkan

--- a/Idra/include/Renderer/RenderingContext.h
+++ b/Idra/include/Renderer/RenderingContext.h
@@ -18,6 +18,6 @@ namespace Idra {
 		virtual const std::string& GetVendor() const = 0;
 		virtual const std::string& GetVersion() const = 0;
 
-		static RenderingContext* Create(GLFWwindow* windowHandle);
+		static Scope<RenderingContext> Create(GLFWwindow* windowHandle);
 	};
 }

--- a/Idra/include/Renderer/Shader.h
+++ b/Idra/include/Renderer/Shader.h
@@ -26,6 +26,6 @@ namespace Idra {
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
-		static Shader* Create(const Path& vertexSrc, const Path& fragmentSrc);		
+		static Ref<Shader> Create(const Path& vertexSrc, const Path& fragmentSrc);		
 	};
 }

--- a/Idra/include/Renderer/Texture.h
+++ b/Idra/include/Renderer/Texture.h
@@ -22,7 +22,7 @@ namespace Idra {
 	class IDRA_API Texture2D : public Texture
 	{
 	public:
-		static Texture2D* Create(const Path& path);
+		static Ref<Texture2D> Create(const Path& path);
 	};
 
 	// @TODO: make a Texture3D & TextureCube class

--- a/Idra/include/Renderer/VertexArray.h
+++ b/Idra/include/Renderer/VertexArray.h
@@ -15,13 +15,13 @@ namespace Idra {
 		virtual void Bind() const = 0;
 		virtual void Unbind() const = 0;
 
-		virtual void AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer) = 0;
-		virtual void SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer) = 0;
+		virtual void AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer) = 0;
+		virtual void SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer) = 0;
 
-		virtual const std::vector<std::shared_ptr<VertexBuffer>>& GetVertexBuffers() const = 0;
-		virtual const std::shared_ptr<IndexBuffer>& GetIndexBuffer() const = 0;
+		virtual const std::vector<Ref<VertexBuffer>>& GetVertexBuffers() const = 0;
+		virtual const Ref<IndexBuffer>& GetIndexBuffer() const = 0;
 
-		static VertexArray* Create();
+		static Ref<VertexArray> Create();
 	};
 
 }

--- a/Idra/include/Resources/Model/Mesh.h
+++ b/Idra/include/Resources/Model/Mesh.h
@@ -16,10 +16,10 @@ namespace Idra {
 		void Bind() const;
 		void Unbind() const;
 
-		inline const std::shared_ptr<VertexArray>& GetVertexArray() const { return m_VertexArray; }
+		inline const Ref<VertexArray>& GetVertexArray() const { return m_VertexArray; }
 
 	private:
-		std::shared_ptr<VertexArray> m_VertexArray;
-		std::shared_ptr<Texture> m_Texture;
+		Ref<VertexArray> m_VertexArray;
+		Ref<Texture> m_Texture;
 	};
 }

--- a/Idra/include/Resources/Model/ModelLoader.h
+++ b/Idra/include/Resources/Model/ModelLoader.h
@@ -23,11 +23,11 @@ namespace Idra {
 	class IDRA_API ModelLoader
 	{
 	public:
-		static Model* LoadModel(ModelLoaderType type, Path source);
+		static Ref<Model> LoadModel(ModelLoaderType type, Path source);
 
 		static std::string ModelLoaderTypeToString(ModelLoaderType type);
 	private:
-		static void ProcessAssimpNode(aiNode* node, const aiScene* scene, Model* model);
+		static void ProcessAssimpNode(aiNode* node, const aiScene* scene, Ref<Model> model);
 		static Mesh ProcessAssimpMesh(aiMesh* mesh, const aiScene* scene);
 	};
 }

--- a/Idra/src/Platform/OpenGL/OpenGLRendererAPI.cpp
+++ b/Idra/src/Platform/OpenGL/OpenGLRendererAPI.cpp
@@ -29,7 +29,7 @@ namespace Idra {
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	}
 
-	void OpenGLRendererAPI::DrawIndexed(const std::shared_ptr<VertexArray>& vertexArray)
+	void OpenGLRendererAPI::DrawIndexed(const Ref<VertexArray>& vertexArray)
 	{
 		glDrawElements(GL_TRIANGLES, vertexArray->GetIndexBuffer()->GetCount(), GL_UNSIGNED_INT, 0);
 	}

--- a/Idra/src/Platform/OpenGL/OpenGLVertexArray.cpp
+++ b/Idra/src/Platform/OpenGL/OpenGLVertexArray.cpp
@@ -47,7 +47,7 @@ namespace Idra {
 		glBindVertexArray(0);
 	}
 
-	void OpenGLVertexArray::AddVertexBuffer(const std::shared_ptr<VertexBuffer>& vertexBuffer)
+	void OpenGLVertexArray::AddVertexBuffer(const Ref<VertexBuffer>& vertexBuffer)
 	{
 		IDRA_CORE_ASSERT(vertexBuffer->GetLayout().GetElements().size(), "Vertex buffer has no layout!");
 
@@ -71,7 +71,7 @@ namespace Idra {
 		m_VertexBuffers.push_back(vertexBuffer);
 	}
 
-	void OpenGLVertexArray::SetIndexBuffer(const std::shared_ptr<IndexBuffer>& indexBuffer)
+	void OpenGLVertexArray::SetIndexBuffer(const Ref<IndexBuffer>& indexBuffer)
 	{
 		glBindVertexArray(m_RendererID);
 

--- a/Idra/src/Platform/Windows/WindowsWindow.cpp
+++ b/Idra/src/Platform/Windows/WindowsWindow.cpp
@@ -59,7 +59,7 @@ namespace Idra {
 
 		m_Window = glfwCreateWindow((int)props.Width, (int)props.Height, m_Data.Title.c_str(), nullptr, nullptr);
 
-		m_RenderingContext.reset(RenderingContext::Create(m_Window));
+		m_RenderingContext = RenderingContext::Create(m_Window);
 		m_RenderingContext->Init();
 
 		glfwSetWindowUserPointer(m_Window, &m_Data);

--- a/Idra/src/Renderer/Buffer.cpp
+++ b/Idra/src/Renderer/Buffer.cpp
@@ -94,7 +94,7 @@ namespace Idra {
 	// VertexBuffer ////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////
 
-	VertexBuffer* VertexBuffer::Create(const std::vector<float>& vertices)
+	Ref<VertexBuffer> VertexBuffer::Create(const std::vector<float>& vertices)
 	{
 		switch (Renderer::GetAPI())
 		{
@@ -102,7 +102,7 @@ namespace Idra {
 				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!");
 				return nullptr;
 			case RendererAPI::API::OpenGL:
-				return new OpenGLVertexBuffer(vertices);
+				return CreateRef<OpenGLVertexBuffer>(vertices);
 			case RendererAPI::API::DirectX:
 				IDRA_CORE_ASSERT(false, "RendererAPI::DirectX is not supported!");
 				return nullptr;
@@ -119,7 +119,7 @@ namespace Idra {
 	// IndexBuffer /////////////////////////////////////////////////////////
 	////////////////////////////////////////////////////////////////////////
 
-	IndexBuffer* IndexBuffer::Create(const std::vector<uint32_t>& indices)
+	Ref<IndexBuffer> IndexBuffer::Create(const std::vector<uint32_t>& indices)
 	{
 		switch (Renderer::GetAPI())
 		{
@@ -127,7 +127,7 @@ namespace Idra {
 				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!"); 
 				return nullptr;
 			case RendererAPI::API::OpenGL:
-				return new OpenGLIndexBuffer(indices);
+				return CreateRef<OpenGLIndexBuffer>(indices);
 			case RendererAPI::API::DirectX:
 				IDRA_CORE_ASSERT(false, "RendererAPI::DirectX is not supported!");
 				return nullptr;

--- a/Idra/src/Renderer/Camera.cpp
+++ b/Idra/src/Renderer/Camera.cpp
@@ -11,7 +11,7 @@ namespace Idra {
 
 	}
 
-	Camera* Camera::CreateCamera(CameraProjectionType type, const void* spec)
+	Ref<Camera> Camera::CreateCamera(CameraProjectionType type, const void* spec)
 	{
 		switch (type)
 		{
@@ -31,7 +31,7 @@ namespace Idra {
 					pSpec = &defaultSpec;
 				}
 
-				return new PerspectiveCamera(pSpec->FOV, pSpec->AspectRatio, pSpec->NearClip, pSpec->FarClip);
+				return CreateRef<PerspectiveCamera>(pSpec->FOV, pSpec->AspectRatio, pSpec->NearClip, pSpec->FarClip);
 			}
 
 			case CameraProjectionType::Orthographic:
@@ -46,7 +46,7 @@ namespace Idra {
 					oSpec = &defaultSpec;
 				}
 
-				return new OrthographicCamera(oSpec->Left, oSpec->Right, oSpec->Bottom, oSpec->Top, oSpec->NearClip, oSpec->FarClip);
+				return CreateRef<OrthographicCamera>(oSpec->Left, oSpec->Right, oSpec->Bottom, oSpec->Top, oSpec->NearClip, oSpec->FarClip);
 			}
 		}
 

--- a/Idra/src/Renderer/CameraController.cpp
+++ b/Idra/src/Renderer/CameraController.cpp
@@ -3,7 +3,7 @@
 #include "Renderer/EditorCameraController.h"
 
 namespace Idra {
-    CameraController* Idra::CameraController::CreateCameraController(CameraControllerType type)
+    Ref<CameraController> Idra::CameraController::CreateCameraController(CameraControllerType type)
     {
 		switch (type)
 		{
@@ -11,7 +11,7 @@ namespace Idra {
 				IDRA_CORE_ASSERT(false, "CameraControllerType::None is not a valid type!"); // #DEBUG
 				return nullptr;
 			case CameraControllerType::EditorCamera:
-				return new EditorCameraController();
+				return CreateRef<EditorCameraController>();
 			case CameraControllerType::FreeCamera:
 				IDRA_CORE_ASSERT(false, "CameraControllerType::FreeCamera is not implemented yet!"); // #DEBUG
 				return nullptr;

--- a/Idra/src/Renderer/RenderCommand.cpp
+++ b/Idra/src/Renderer/RenderCommand.cpp
@@ -1,6 +1,6 @@
 #include "Renderer/RenderCommand.h"
 
 namespace Idra {
-	RendererAPI* RenderCommand::s_RendererAPI = RendererAPI::Create();
+	Scope<RendererAPI> RenderCommand::s_RendererAPI = RendererAPI::Create();
 
 }

--- a/Idra/src/Renderer/Renderer.cpp
+++ b/Idra/src/Renderer/Renderer.cpp
@@ -12,7 +12,7 @@ namespace Idra {
 		RenderCommand::Init();
 	}
 
-	const void Renderer::BeginScene(const std::shared_ptr<Camera>& camera)
+	const void Renderer::BeginScene(const Ref<Camera>& camera)
 	{
 		s_SceneData.ViewProjectionMatrix = camera->GetViewProjectionMatrix();
 	}
@@ -22,7 +22,7 @@ namespace Idra {
 
 	}
 
-	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<Mesh>& mesh, const TransformComponent& transform)
+	void Renderer::Submit(const Ref<Shader>& shader, const Ref<Mesh>& mesh, const TransformComponent& transform)
 	{
 		shader->Bind();
 		std::dynamic_pointer_cast<OpenGLShader>(shader)->SetUniformMat4f("u_ViewProjection", s_SceneData.ViewProjectionMatrix);
@@ -33,7 +33,7 @@ namespace Idra {
 		RenderCommand::DrawIndexed(mesh->GetVertexArray());
 	}
 
-	void Renderer::Submit(const std::shared_ptr<Shader>& shader, const std::shared_ptr<Model>& model, const TransformComponent& transform)
+	void Renderer::Submit(const Ref<Shader>& shader, const Ref<Model>& model, const TransformComponent& transform)
 	{
 		shader->Bind();
 		std::dynamic_pointer_cast<OpenGLShader>(shader)->SetUniformMat4f("u_ViewProjection", s_SceneData.ViewProjectionMatrix);

--- a/Idra/src/Renderer/RendererAPI.cpp
+++ b/Idra/src/Renderer/RendererAPI.cpp
@@ -6,7 +6,7 @@ namespace Idra {
 	// @TODO: Set this to the renderer API of your choice
 	RendererAPI::API RendererAPI::s_API = RendererAPI::API::OpenGL;
 
-	RendererAPI* RendererAPI::Create()
+	Scope<RendererAPI> RendererAPI::Create()
 	{
 		switch (s_API)
 		{
@@ -14,7 +14,7 @@ namespace Idra {
 				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!");
 				return nullptr;
 			case RendererAPI::API::OpenGL:
-				return new OpenGLRendererAPI();
+				return CreateScope<OpenGLRendererAPI>();
 			case RendererAPI::API::DirectX:
 				IDRA_CORE_ASSERT(false, "RendererAPI::DirectX is not supported!");
 				return nullptr;

--- a/Idra/src/Renderer/RendererContext.cpp
+++ b/Idra/src/Renderer/RendererContext.cpp
@@ -7,9 +7,9 @@
 #include <GLFW/glfw3.h>
 
 namespace Idra {
-	RenderingContext* RenderingContext::Create(GLFWwindow* windowHandle)
+	Scope<RenderingContext> RenderingContext::Create(GLFWwindow* windowHandle)
 	{
 		//@TODO: Some work will need to be done to refactor this to use a switch on the enum of RendererAPI
-		return new OpenGLContext(windowHandle);
+		return CreateScope<OpenGLContext>(windowHandle);
 	}
 }

--- a/Idra/src/Renderer/Shader.cpp
+++ b/Idra/src/Renderer/Shader.cpp
@@ -4,7 +4,7 @@
 #include "Platform/OpenGL/OpenGLShader.h"
 
 namespace Idra {
-	Shader* Shader::Create(const Path& vertexSrc, const Path& fragmentSrc)
+	Ref<Shader> Shader::Create(const Path& vertexSrc, const Path& fragmentSrc)
 	{
 		switch (Renderer::GetAPI())
 		{
@@ -12,7 +12,7 @@ namespace Idra {
 				IDRA_CORE_ASSERT(false, "RendererAPI::None is not supported!"); 
 				return nullptr;
 			case RendererAPI::API::OpenGL: 
-				return new OpenGLShader(vertexSrc, fragmentSrc);
+				return CreateRef<OpenGLShader>(vertexSrc, fragmentSrc);
 			case RendererAPI::API::Vulkan: 
 				IDRA_CORE_ASSERT(false, "RendererAPI::Vulkan is not supported!"); 
 				return nullptr;

--- a/Idra/src/Renderer/Texture.cpp
+++ b/Idra/src/Renderer/Texture.cpp
@@ -6,7 +6,7 @@
 #include "Platform/OpenGL/OpenGLTexture.h"
 
 namespace Idra {
-	Texture2D* Texture2D::Create(const Path& path)
+	Ref<Texture2D> Texture2D::Create(const Path& path)
 	{
 		switch (Renderer::GetAPI())
 		{
@@ -15,7 +15,7 @@ namespace Idra {
 			return nullptr;
 
 		case RendererAPI::API::OpenGL:
-			return new OpenGLTexture2D(path);
+			return CreateRef<OpenGLTexture2D>(path);
 
 		case RendererAPI::API::DirectX:
 			IDRA_CORE_ASSERT(false, "RendererAPI::DirectX is not supported!");

--- a/Idra/src/Renderer/VertexArray.cpp
+++ b/Idra/src/Renderer/VertexArray.cpp
@@ -6,7 +6,7 @@
 #include "Platform/OpenGL/OpenGLVertexArray.h"
 
 namespace Idra {
-	VertexArray* VertexArray::Create()
+	Ref<VertexArray> VertexArray::Create()
 	{
 		switch (Renderer::GetAPI())
 		{
@@ -14,7 +14,7 @@ namespace Idra {
 				IDRA_ASSERT(false, "RendererAPI::None is currently not supported!"); 
 				return nullptr;
 			case RendererAPI::API::OpenGL:
-				return new OpenGLVertexArray();
+				return CreateRef<OpenGLVertexArray>();
 			case RendererAPI::API::DirectX:
 				IDRA_ASSERT(false, "RendererAPI::DirectX is currently not supported!");
 				return nullptr;

--- a/Idra/src/Resources/Model/Mesh.cpp
+++ b/Idra/src/Resources/Model/Mesh.cpp
@@ -5,15 +5,15 @@
 namespace Idra {
 	Mesh::Mesh(const std::vector<float>& vBO, const BufferLayout& bLO, const std::vector<uint32_t>& iBO)
 	{
-		m_VertexArray.reset(VertexArray::Create());
+		m_VertexArray = VertexArray::Create();
 
-		std::shared_ptr<VertexBuffer> vertexBuffer;
-		vertexBuffer.reset(VertexBuffer::Create(vBO));
+		Ref<VertexBuffer> vertexBuffer;
+		vertexBuffer = VertexBuffer::Create(vBO);
 		vertexBuffer->SetLayout(bLO);
 		m_VertexArray->AddVertexBuffer(vertexBuffer);
 
-		std::shared_ptr<IndexBuffer> indexBuffer;
-		indexBuffer.reset(IndexBuffer::Create(iBO));
+		Ref<IndexBuffer> indexBuffer;
+		indexBuffer = IndexBuffer::Create(iBO);
 		m_VertexArray->SetIndexBuffer(indexBuffer);
 	}
 

--- a/Idra/src/Resources/Model/ModelLoader.cpp
+++ b/Idra/src/Resources/Model/ModelLoader.cpp
@@ -3,7 +3,7 @@
 #include "Resources/Model/ModelLoader.h"
 
 namespace Idra {
-	Model* ModelLoader::LoadModel(ModelLoaderType type, Path source)
+	Ref<Model> ModelLoader::LoadModel(ModelLoaderType type, Path source)
 	{
 		switch (type)
 		{
@@ -25,7 +25,7 @@ namespace Idra {
 					return nullptr;
 				}
 
-				Model* model = new Model(source.stem().string());
+				Ref<Model> model = CreateRef<Model>(source.stem().string());
 				ProcessAssimpNode(scene->mRootNode, scene, model);
 				return model;
 			}
@@ -48,7 +48,7 @@ namespace Idra {
 		}
 	}
 
-	void ModelLoader::ProcessAssimpNode(aiNode* node, const aiScene* scene, Model* model)
+	void ModelLoader::ProcessAssimpNode(aiNode* node, const aiScene* scene, Ref<Model> model)
 	{
 		// Process all the meshes in this node
 		for (uint32_t i = 0; i < node->mNumMeshes; i++)


### PR DESCRIPTION
This pull request introduces a significant refactor across the codebase to replace the use of `std::shared_ptr` and `std::unique_ptr` with custom-defined `Ref` and `Scope` types for improved readability and consistency. The changes affect various components, including resource management, rendering, and initialization logic.

### Refactor to use `Ref` and `Scope` types:
* [`Idra/include/Core/Core.h`](diffhunk://#diff-4e633778c3e6275f70bcbf35c1d53abf161aacb0c0228ae3cea7b84c6da4ad5fR35-R52): Introduced `Ref` (alias for `std::shared_ptr`) and `Scope` (alias for `std::unique_ptr`) types, along with helper functions `CreateRef` and `CreateScope`.

### Updates to class members and methods:
* [`Editor/include/SandboxLayer.h`](diffhunk://#diff-6f45d80fb4c8738e6a16e0c636bcc67098d95fc23a0119b8952a6afcd58b33baL42-R49): Replaced `std::shared_ptr` with `Idra::Ref` for shaders, models, textures, camera, and camera controller. [[1]](diffhunk://#diff-6f45d80fb4c8738e6a16e0c636bcc67098d95fc23a0119b8952a6afcd58b33baL42-R49) [[2]](diffhunk://#diff-6f45d80fb4c8738e6a16e0c636bcc67098d95fc23a0119b8952a6afcd58b33baL58-R59)
* [`Editor/src/SandboxLayer.cpp`](diffhunk://#diff-1ced46f15955f1d94f090a39911af64e03e613897494f8bdcc1af935213ace91L20-R51): Updated initialization logic to use `Idra::Ref` instead of `std::shared_ptr` for resources like cameras, models, textures, and shaders. Removed the use of `reset()` for assignment.

### Updates to rendering-related APIs:
* `Idra/include/Renderer/Buffer.h`, `Idra/include/Renderer/VertexArray.h`, `Idra/include/Renderer/Shader.h`, `Idra/include/Renderer/Texture.h`: Updated APIs to use `Ref` and `Scope` for resource management, replacing raw pointers and `std::shared_ptr`. [[1]](diffhunk://#diff-14141c1b511f893896b0017feb58e575c410e7c5e934e56aa1ba84880b014477L92-R92) [[2]](diffhunk://#diff-56d16077255158fcd0754395cbcb25507a0d75154014188f3d51a6895451dbdfL18-R24) [[3]](diffhunk://#diff-ad64f5ee9d89ac90a44f90127f679a4629e035be48eadbb0e88e6dbb4afaefc2L29-R29) [[4]](diffhunk://#diff-05c9c3d14fadf18adbcec5abc6a3bd3b7a51591278c91c53843eaff22c86165dL25-R25)
* `Idra/include/Renderer/RendererAPI.h`, `Idra/include/Renderer/RenderCommand.h`: Updated `DrawIndexed` and other methods to use `Ref` for vertex arrays and `Scope` for `RendererAPI` instances. [[1]](diffhunk://#diff-58ff6c650d4acdbb2b1b8f41951628a5c88e6e7ec21246cf6e4b7d8ebcd043a5L26-R31) [[2]](diffhunk://#diff-82cc4025a542ce3fa509a2829045b9b2938c7401b8d900d079e1c67394efadedL26-R31)

### Platform-specific updates:
* `Idra/src/Platform/OpenGL/OpenGLRendererAPI.cpp`, `Idra/src/Platform/OpenGL/OpenGLVertexArray.cpp`: Updated OpenGL implementations to use `Ref` for vertex arrays, vertex buffers, and index buffers. [[1]](diffhunk://#diff-51f9ed42e8fd0c2b356663095a600a94f9732044a781e459972a19d7f45e9fcdL32-R32) [[2]](diffhunk://#diff-e4fe4a401531b4ad4f7c8db078ea32b5b7777fe281d0c746d3c39b208c88cee6L50-R50) [[3]](diffhunk://#diff-e4fe4a401531b4ad4f7c8db078ea32b5b7777fe281d0c746d3c39b208c88cee6L74-R74)
* [`Idra/src/Platform/Windows/WindowsWindow.cpp`](diffhunk://#diff-d364e247642f8048e29fb9d3a11402000e1efd2b012049619ee7a6800cb86b21L62-R62): Replaced `std::unique_ptr` with `Scope` for managing the rendering context.

### Resource loading updates:
* [`Idra/include/Resources/Model/ModelLoader.h`](diffhunk://#diff-7a0747b6a11c9ce706efd2d4228cde7d87bcfc0f408acca74f68d36f8d00fae2L26-R30): Updated model loading API to return `Ref<Model>` instead of raw pointers. Adjusted internal methods to use `Ref<Model>` for consistency.